### PR TITLE
Fix Navbar responsiveness, card images width

### DIFF
--- a/assets/css/navbar.css
+++ b/assets/css/navbar.css
@@ -55,7 +55,7 @@
     display: none;
   }
   
-  @media (min-width: 840px) {
+  @media (min-width: 1100px) {
     .nav > .nav-links {
       font-size: 18px;
       margin: auto 50px;
@@ -67,7 +67,7 @@
     }
   }
   
-  @media (max-width: 840px) {
+  @media (max-width: 1100px) {
     .nav {
       background: #0D1634;
     }

--- a/assets/css/previousEvents.css
+++ b/assets/css/previousEvents.css
@@ -219,6 +219,7 @@ h1{
 .clash-card {
   background: white;
   width: 350px;
+  height: 100%;
   display: inline-block;
   border-radius: 19px;
   position: relative;
@@ -259,14 +260,14 @@ h1{
   transition: width 0.5s ease-in-out;
 }
 .wrapper:hover .clash-card__image--barbarian img {
-  width: 120%;
+  width: 130%;
 }
 
 .clash-card__image--archer {
   background: #1f2833;
 }
 .clash-card__image--archer img {
-  width: 120%;
+  width: 100%;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -275,7 +276,7 @@ h1{
 }
 
 .wrapper:hover .clash-card__image--archer img {
-  width: 140%;
+  width: 130%;
 }
 
 .clash-card__image--wizard {
@@ -292,7 +293,7 @@ h1{
 }
 
 .wrapper:hover .clash-card__image--wizard img {
-  width: 120%;
+  width: 130%;
 }
 
 .clash-card__level {

--- a/assets/css/sponsors.css
+++ b/assets/css/sponsors.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins&display=swap');
+
+
 .abs,
 h2:after,
 .cards .card figcaption,
@@ -235,12 +238,18 @@ h2:after {
   font-size: 1.5em;
   margin: 30px auto 20px !important;
 }
-.sponserHeader{
-  padding: 70px;
+.sponsorHeader{
+  padding: 60px;
+  font-family: 'Poppins', sans-serif;
+  font-size: 4rem;
 }
 
 @media screen and (max-width: 770px) {
   .card {
     margin: 20px !important;
+  }
+  .sponsorHeader
+  {
+    font-size: 3rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
                   />
                 </div>
                 <div class="clash-card__level clash-card__level--barbarian">
-                  OFLINE
+                  OFFLINE
                 </div>
                 <div class="clash-card__unit-name">TECHNITI</div>
                 <div class="clash-card__unit-description">
@@ -393,7 +393,7 @@
                   />
                 </div>
                 <div class="clash-card__level clash-card__level--barbarian">
-                  OFLINE
+                  OFFLINE
                 </div>
                 <div class="clash-card__unit-name">CURSED WEEK</div>
                 <div class="clash-card__unit-description">
@@ -453,7 +453,7 @@
 
     <!--Our Past Sponsors-->
     <section>
-      <h2 class="sponserHeader">
+      <h2 class="sponsorHeader">
         <strong>Past Sponsors<span></span></strong>
       </h2>
 


### PR DESCRIPTION
Navbar was being disturbed at 953 px, so added breakpoint at 1100px instead of 840px(previously). Made card images width uniform. 